### PR TITLE
Kong 0.10.x

### DIFF
--- a/kong/monitor.js
+++ b/kong/monitor.js
@@ -44,11 +44,11 @@ const checkKongVersion = function (app, callback) {
 };
 
 const checkKongCluster = function (app, callback) {
-    utils.kongGet(app, 'cluster', function (err, body) {
+    utils.kongGet(app, 'status', function (err, body) {
         if (err)
             return callback(err);
-        if (!body.total) {
-            const err = new Error('Kong answer from /cluster did not contain "total" property.');
+        if (!body.database) {
+            const err = new Error('Kong answer from /status did not contain "database" property.');
             err.status = 500;
             return callback(err);
         }

--- a/kong/portal.js
+++ b/kong/portal.js
@@ -132,7 +132,7 @@ function checkRequestTransformerPlugin(app, apiConfig, plugin) {
 
         for (var i = 0; i < plugin.config.add.headers.length; ++i) {
             if (plugin.config.add.headers[i] == '%%Forwarded') {
-                var prefix = apiConfig.api.request_path;
+                var prefix = apiConfig.api.uris;
                 var proto = app.kongGlobals.network.schema;
                 var rawHost = app.kongGlobals.network.apiHost;
                 var host;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "name": "portal-kong-adapter",
   "config": {
-    "kongversion": "0.9.9"
+    "kongversion": "0.11.0"
   }
 }

--- a/resources/deploy-api.json
+++ b/resources/deploy-api.json
@@ -5,9 +5,9 @@
   "config": {
     "api": {
       "upstream_url": "(filled dynamically)/deploy",
-      "request_path": "/deploy/v1",
+      "uris": ["/deploy/v1"],
       "preserve_host": false,
-      "strip_request_path": true,
+      "strip_uri": true,
       "name": "deploy-api-internal"
     },
     "plugins": [

--- a/resources/ping-api.json
+++ b/resources/ping-api.json
@@ -5,9 +5,9 @@
   "config": {
     "api": {
       "upstream_url": "(filled dynamically)/ping",
-      "request_path": "/ping-portal",
+      "uris": ["/ping-portal"],
       "preserve_host": false,
-      "strip_request_path": true,
+      "strip_uri": true,
       "name": "ping-portal"
     },
     "plugins": [

--- a/resources/portal-api.json
+++ b/resources/portal-api.json
@@ -8,9 +8,9 @@
   "config": {
     "api": {
       "upstream_url": "(filled dynamically)/",
-      "request_path": "/portal-api/v1",
+      "uris": ["/portal-api/v1"],
       "preserve_host": false,
-      "strip_request_path": true,
+      "strip_uri": true,
       "name": "portal-api-internal"
     },
     "plugins": [

--- a/resources/swagger-ui.json
+++ b/resources/swagger-ui.json
@@ -5,9 +5,9 @@
   "config": {
     "api": {
       "upstream_url": "(filled dynamically)/swagger-ui",
-      "request_path": "/swagger-ui",
+      "uris": ["/swagger-ui"],
       "preserve_host": false,
-      "strip_request_path": true,
+      "strip_uri": true,
       "name": "swagger-ui-portal"
     },
     "plugins": [


### PR DESCRIPTION
This is really changes up to new kong version 0.11.0.

/cluster endpoint is deprecated, so  we have to use something else instead, /status is very close alternative.