### PR TITLE
inject JWT Auth -- allow for user to specify jwt as an auth method us…

### DIFF
--- a/genDockerfile.sh
+++ b/genDockerfile.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+perl -pe 's;(\\*)(\$([a-zA-Z_][a-zA-Z_0-9]*)|\$\{([a-zA-Z_][a-zA-Z_0-9]*)\})?;substr($1,0,int(length($1)/2)).($2&&length($1)%2?$2:$ENV{$3||$4});eg' Dockerfile.template > Dockerfile-alpine
+

--- a/kong/kong.js
+++ b/kong/kong.js
@@ -314,6 +314,7 @@ kong.CONSUMER_PLUGINS = [
     "oauth2",
     "key-auth",
     "basic-auth",
+    "jwt",
     "hmac-auth"
 ];
 


### PR DESCRIPTION
Here's one way to do what I was trying to get done, I've made a few assumptions, so feel free to reject and suggest a different design. What I have here is a global configuration for JWT verification supporting a single public key for any APIs using the jwt authentication. I currently have it hardcoded to RS256 and my configuration lives in the globals.json file. I haven't touched the portal, so support on the frontend is non-existent currently. 

To configure, in globals.json, under "auth", I expect a new item called "jwt" with two keys: "key", which will map to the required "iss" claim in the generated jwt, and "rsa_public_key", which is the key to be used for verification. Here's an example of the object:
```
"jwt" : {
      "key": "issuer_name",
      "rsa_public_key": "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDePma1EUq2siCZfYm0yNVVtVu+\nyl2b6TgyZASL66mp6xEHTEr2GFq/egZAMB1Kb3XIKV97teZtSpgg02ctCFyiMYui\ns06nJXzvPHOJW02YNHM0ZiTcCrfBjBAzEOG4MZuBbQNY9IYT0Shbl32Q8OLPAkdK\nKA0Zr7qm4uHRI5ENyQIDAQAB\n-----END PUBLIC KEY-----\n"
    }
```
As you had mentioned, the JWT needs to be created externally and I currently have only gotten that done through command line tools (little integration). Just wanted to share in case this sparked some ideas on what this should look like.